### PR TITLE
Fix checksum install function

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -7,11 +7,11 @@ checkShasum ()
 
   if $(command -v sha256sum >/dev/null 2>&1); then
         sha256sum \
-                -c <<<"$authentic_checksum $archive_file_name"
+                -c <<<"$authentic_checksum  $archive_file_name"
   elif $(command -v shasum >/dev/null 2>&1); then
     shasum \
       -a 256 \
-      -c <<<"$authentic_checksum $archive_file_name"
+      -c <<<"$authentic_checksum  $archive_file_name"
   else
     echo "sha256sum or shasum is not available for use" >&2
     return 1


### PR DESCRIPTION
The checksum function fails to work on Alpine linux due to a missing space between the filename and the checksum.

I tested on a Mac and a single space and a double space both validate correctly. That leads me to believe that this is a difference between linux and bsd tooling.