### PR TITLE
Added latest-stable script in order to reliably return actual latest version

### DIFF
--- a/bin/latest-stable
+++ b/bin/latest-stable
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+query="${1:-}"
+asdf list all gradle "$query" | grep -ivE "(^Available version:|-src|-dev|-latest|-stm|[-\\.]rc|-milestone|-alpha|-beta|[-\\.]pre|-next|(a|b|c)[0-9]+|snapshot|master)" | sed 's/^[[:space:]]\+//' | tail -1


### PR DESCRIPTION
Fix for #10 

Note that this uses the same technique shown in [this PR](https://github.com/asdf-vm/asdf/pull/1307#issuecomment-1190120483) to main asdf project, combined with `latest-stable` script, such as [the one](https://github.com/asdf-community/asdf-kubectl/blob/master/bin/latest-stable) that I contributed to the asdf-kubectl project.

However, no fetch of the latest gradle stable version via a direct curl to a well-known URL (like I did in kubectl's asdf plugin) is used here, basically since I do not know whether such that address exists for gradle (I have searched a bit to find it, but with no luck). I'd happy to extend the script with such direct mechanism, if someone is aware of that address for gradle and can say which is it.