### PR TITLE
FIX: Error on sort versions

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -1,2 +1,2 @@
 #!/bin/sh 
-curl -s https://services.gradle.org/distributions/ | grep -e "distributions.*-bin.zip\"" | sed -e "s#^.*distributions/gradle-##" -e "s#-bin.zip.*##" | sort -t. -n | paste -s -d" " -
+curl -s https://services.gradle.org/distributions/ | grep -e "distributions.*-bin.zip\"" | sed -e "s#^.*distributions/gradle-##" -e "s#-bin.zip.*##" | sort -t. | paste -s -d" " -


### PR DESCRIPTION
On run asdf install gradle latest the version installed is 4.10.3 (the correct today and last lts is 7.5.1)

See for more details:
https://github.com/rfrancis/asdf-gradle/issues/12