### PR TITLE
check for `unzip` command before executing

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -43,6 +43,12 @@ installGradleSig()
           echo "Authenticity of package archive can not be assured. Exiting." >&2
           exit 1
     fi
+
+    echo 'start unzip check'
+    if ! command -v unzip  &> /dev/null; then
+	    echo "Unzip is not installed. Please install unzip and try again."
+	    exit 1
+    fi
   
   	unzip gradle-${ASDF_INSTALL_VERSION}-bin.zip
   	rm gradle-${ASDF_INSTALL_VERSION}-bin.zip
@@ -61,6 +67,13 @@ installGradleNoSign()
   	mkdir -p "$ASDF_INSTALL_PATH"
   	cd "$ASDF_INSTALL_PATH" || exit 1
   	curl -OJL ${GRADLE_DISTRIBUTION_URL}/gradle-${ASDF_INSTALL_VERSION}-bin.zip
+
+    echo 'start unzip check'
+    if ! command -v unzip  &> /dev/null; then
+      echo "Unzip is not installed. Please install unzip and try again."
+      exit 1
+    fi
+
   	unzip gradle-${ASDF_INSTALL_VERSION}-bin.zip
   	rm gradle-${ASDF_INSTALL_VERSION}-bin.zip
   	mv gradle-${ASDF_INSTALL_VERSION}/* .


### PR DESCRIPTION
While using this plugin to install gradle on a relatively fresh Debian system under WSL2, I got an error about `unzip` command not being found. However, this plugin stated that the install had succeeded.

This change is to check that the `unzip` command exists before attempting to execute it. If it does not exist, exit with an error code.