### PR TITLE
fix: search bash executable by /usr/bin/env

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 export GRADLE_DISTRIBUTION_URL=${GRADLE_DISTRIBUTION_URL:=https://services.gradle.org/distributions}
 


### PR DESCRIPTION
This helps to solve problems finding the `bash` executable on systems that might not use very standard paths - such as `NixOS`, where I found the problem for my installation.

From experience, I might say the amount of use cases having a `/usr/bin/env` available, might be greater than the amount of systems having the bash exactly at `/bin/bash`. Doing a little research, I found that most plugins come with this `/usr/bin/env` functionality and seem to have no problems with it at all.

 1. Trying to install a Gradle version without the change
![image](https://github.com/rfrancis/asdf-gradle/assets/32501305/7a2c7c16-39a8-4f19-9fce-e91c2abdb22e)

 2. After the small change to the script in `~/.asdf/plugins/gradle/bin/install`, the installation goes smoothly
![image](https://github.com/rfrancis/asdf-gradle/assets/32501305/45bd2636-80ba-4aa6-ae4d-3caf0f64f1f5)


I hope this helps.