### PR TITLE
[list-all] Properly detect minor versions containing 2 digits

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -1,10 +1,10 @@
-#!/bin/sh 
+#!/bin/sh
 
 export LC_ALL=C
-export GRADLE_DISTRIBUTION_URL=${GRADLE_DISTRIBUTION_URL:=https://services.gradle.org/distributions}
+export GRADLE_DISTRIBUTION_URL=${GRADLE_DISTRIBUTION_URL:-https://services.gradle.org/distributions}
 
-curl -s ${GRADLE_DISTRIBUTION_URL}/ |
-  grep -e "gradle.*-bin.zip\"" |
-  sed -e "s#^.*gradle-##" -e "s#-bin.zip.*##" |
-  sort -t. -n |
-  paste -s -d" " -
+exec curl -fsSL "${GRADLE_DISTRIBUTION_URL}" |
+  grep 'gradle.*-bin.zip"' |
+  sed 's#^.*gradle-##;s#-bin.zip.*##' |
+  sort -V |
+  tr '\n' ' '


### PR DESCRIPTION
And minor tool refactoring. (This patch is required to install 8.10.)