### PR TITLE
Fix install on macOS Sequoia

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -31,7 +31,7 @@ checkShasum() {
 
   log 'check sha256sum'
   if has_command sha256sum; then
-    sha256sum -c <<<"$authentic_checksum  $archive_file_name"
+    sha256sum -c <<<"$authentic_checksum  $archive_file_name" -
   elif has_command shasum; then
     shasum -a 256 -c <<<"$authentic_checksum  $archive_file_name"
   else


### PR DESCRIPTION
Without the extra dash sha256sum is failing for me on macOS Sequoia.

```sh
❯ sw_vers
ProductName:		macOS
ProductVersion:		15.0.1
BuildVersion:		24A348
❯ uname -m
arm64
❯ sha256sum -c <<<"31c55713e40233a8303827ceb42ca48a47267a0ad4bab9177123121e71524c26  gradle-8.10.2-bin.zip"
usage: sha256sum [-bctwz] [files ...]
❯ echo $?
1
❯ sha256sum -c <<<"31c55713e40233a8303827ceb42ca48a47267a0ad4bab9177123121e71524c26  gradle-8.10.2-bin.zip" -
gradle-8.10.2-bin.zip: OK
❯ echo $?
0
```